### PR TITLE
Fix public-ip version/promise issue and file/route-53 desync issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Requirements
 Installation
 ------------
 1. Install node via DSM store
-2. Download / copy-paste script synoDNSUpdater.js to a local folder on the NAS filesystem
+2. Download / copy-paste script synoDNSUpdater.js and package.json to a local folder on the NAS filesystem
 3. Install node dependencies along with the script :
 ```
-  npm install public-ip aws-sdk
+  npm install
 ```
 4. Edit the configuration of the script with required settings
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
         "dns"
     ],
     "dependencies": {
-        "public-ip": "1.0.3",
-        "aws-sdk": "2.1.45"
+        "aws-sdk": "^2.72.0",
+        "bluebird": "^3.5.0",
+        "public-ip": "^2.3.5"
     },
     "preferGlobal": false,
     "private": true,


### PR DESCRIPTION
This PR fixes a few issues:

* The installation instructions now recommend using package.json & npm install to get expected library versions
* public-ip updated to use promises; redesigned the program flow to use promises
* instead of using a file to store the IP, live-checks Route 53, which can prevent a situation that has the current IP and file IP matching, but Route 53 having in incorrrect IP
* More documentation of config values in the script